### PR TITLE
Add Privacy Policy + Terms of Use and tighten cookie consent for Over…

### DIFF
--- a/privacy-policy.md
+++ b/privacy-policy.md
@@ -1,39 +1,69 @@
 ---
 layout: privacy
 ---
-# Cookie Policy
+# Privacy Policy
 
-**Last updated:** Aug 21 2025
+**Last updated:** June 4 2026
 
 ### TL;DR
 
-**IN HUMAN LANGUAGE:** We simply use cookies to count how many people visit our website and how many times they click the download button!
+**IN HUMAN LANGUAGE:** aimii runs entirely on your own computer. Your settings and the games we detect never leave your device — we have no servers and no accounts. The app is free because it shows ads served through Overwolf, and Overwolf's ad system collects some basic device info to do that. That's the whole story.
 
 ---
 
+aimii.app ("aimii", "we", "us") is a free desktop application, built on the Overwolf platform, that normalizes your mouse sensitivity across games. This Privacy Policy explains what data is collected when you use the app and this website.
 
-Our website uses cookies to improve your browsing experience and to analyze site traffic.
+This Privacy Policy is an agreement between you and aimii.app. It is **not** concluded with Overwolf. Overwolf operates the platform aimii runs on and is governed by its own [Platform Privacy Policy](https://legal.overwolf.com/docs/overwolf/platform/platform-privacy-policy/).
 
-### What We Collect
+### The app
 
-We use **Google Analytics**, a web analytics service provided by Google LLC ("Google"). Google Analytics uses cookies to help us understand how visitors interact with our website.
+**aimii has no user accounts, requires no login, and operates no servers of its own.** As a result:
 
-These cookies collect information such as your IP address, browser type, and pages visited, but do **not** identify you personally.
+- **Your settings** — your baseline game, sensitivity, and mouse DPI — are stored only locally on your computer. They are never transmitted to us or anyone else.
+- **Game detection** — to convert your sensitivity, aimii detects which supported game is currently running on your machine. This happens locally on your device and is not sent to us or stored remotely.
+- **No analytics, telemetry, or crash reporting** is sent from the app to us.
 
-### How We Use This Data
+We genuinely don't receive any personal data from the app, because there is nowhere for it to go.
 
-The data collected by Google Analytics is used to generate reports that help us improve our website and services.
+### Advertising (Overwolf)
 
-### Your Choices
+aimii is free and supported by ads. Advertising in the app is delivered through Overwolf's advertising technology, embedded as part of the Overwolf platform.
 
-- **EU/International Users**: We ask for your consent before setting any cookies
-- **US/Canada Users**: Cookies are enabled by default, but you can opt out at any time
+- aimii does **not** collect, receive, or share your personal data with advertisers.
+- Instead, **Overwolf and its advertising partners collect data directly from your device** through their embedded advertising technology (SDK). This may include device identifiers, an IP-based approximate location, and ad-interaction data, used to serve and measure ads.
+- This collection is governed by Overwolf's own privacy policy, not ours. See the [Overwolf Platform Privacy Policy](https://legal.overwolf.com/docs/overwolf/platform/platform-privacy-policy/) for details and opt-out options.
 
-You can choose to accept or decline cookies via the cookie consent banner on our site. If you choose to decline, some features of the site may not function properly.
+### This website (aimii.app)
 
-### External Links
+This website uses **Google Analytics** (provided by Google LLC) to understand how visitors use the site. These cookies collect information such as your IP address, browser type, and pages visited, and are used only to generate aggregate reports that help us improve the site. They do not identify you personally.
 
-- For more information about how Google uses data when you use our site, please visit [Google's Privacy & Terms](https://policies.google.com/privacy)
-- You can opt out of Google Analytics entirely by visiting the [Google Analytics Opt-out Browser Add-on](https://tools.google.com/dlpage/gaoptout)
+- **EU/EEA and UK visitors:** we ask for your consent before setting any analytics cookies.
+- **All other visitors:** analytics cookies are enabled by default; you can opt out at any time using the Google Analytics opt-out add-on linked below.
 
+For more on how Google uses this data, see [Google's Privacy & Terms](https://policies.google.com/privacy). You can opt out of Google Analytics entirely with the [Google Analytics Opt-out Browser Add-on](https://tools.google.com/dlpage/gaoptout).
 
+### Who we share data with
+
+We do not sell your personal data. The only third parties involved are:
+
+- **Overwolf** and its advertising partners — collect data directly from your device to serve ads in the app, as described above.
+- **Google** (Google Analytics) — website usage analytics only.
+- **ipapi.co** — when you visit the website, your IP address is sent to ipapi.co to estimate your country, so we can show the appropriate cookie consent options for your region.
+
+aimii also links to external services including **GitHub** (downloads) and **Discord** (community). Those services have their own privacy policies and are outside our control.
+
+### Your choices and rights
+
+Because the app stores everything locally, you can clear your data at any time by resetting or uninstalling the app. For website cookies, use the consent banner to accept or decline.
+
+Depending on where you live, you may have rights under laws such as PIPEDA (Canada), the GDPR (EU/UK), or the CCPA (California) to access, correct, or delete personal data. Since aimii itself holds no personal data on any server, most such requests relate to data collected by Overwolf (advertising) or Google (website analytics) — please refer to their policies linked above. For anything else, contact us below.
+
+### Changes
+
+We may update this Privacy Policy from time to time. The "Last updated" date above reflects the most recent version.
+
+### Contact
+
+Questions, complaints, or requests about this Privacy Policy can be sent to:
+
+**Email:** fevish@gmail.com

--- a/sections/cookie-consent.liquid
+++ b/sections/cookie-consent.liquid
@@ -1,4 +1,4 @@
-{% # - Cookie Consent Bar for GDPR Compliance (Non-North America only) -# %}
+{% # - Cookie Consent Bar for GDPR/UK Compliance (shown to EU/EEA + UK only) -# %}
 <div id="cookie-consent-bar" class="cookie-consent-bar" style="display: none;">
   <div class="container">
     <div class="row align-items-center">
@@ -30,6 +30,10 @@
     const CONSENT_KEY = 'cookie_consent_given';
     const CONSENT_DECLINE_KEY = 'cookie_consent_declined';
     const LOCATION_KEY = 'user_location_checked';
+
+    // Countries where prior opt-in consent is legally required before setting
+    // analytics/advertising cookies (EU/EEA + UK). Everyone else is opt-out.
+    const CONSENT_REQUIRED_COUNTRIES = ['AT', 'BE', 'BG', 'HR', 'CY', 'CZ', 'DK', 'EE', 'FI', 'FR', 'DE', 'GR', 'HU', 'IE', 'IT', 'LV', 'LT', 'LU', 'MT', 'NL', 'PL', 'PT', 'RO', 'SK', 'SI', 'ES', 'SE', 'IS', 'LI', 'NO', 'GB'];
 
     // Test mode flag
     let isTestMode = false;
@@ -109,7 +113,7 @@
       hideConsentBar();
     }
 
-    // Function to check if user is outside North America
+    // Function to check the visitor's country and gate consent accordingly
     function checkUserLocation() {
       if (isTestMode) {
         return;
@@ -143,17 +147,15 @@
           localStorage.setItem(LOCATION_KEY, new Date().toISOString());
 
           if (data.country_code) {
-            // Check if user is outside North America
-            const safeCountries = ['US', 'CA', 'MX', 'AU', 'NZ', 'JP', 'KR', 'SG', 'HK'];
-            const isNorthAmerica = safeCountries.includes(data.country_code);
-            const shouldShowBar = !isNorthAmerica;
+            // Only EU/EEA + UK visitors are prompted; everyone else is opt-out.
+            const shouldShowBar = CONSENT_REQUIRED_COUNTRIES.includes(data.country_code);
 
             localStorage.setItem('show_consent_bar', shouldShowBar.toString());
 
             if (shouldShowBar) {
               showConsentBar();
             } else {
-              // Auto-grant consent for North American users
+              // Auto-grant consent for visitors outside the EU/EEA + UK
               if (window.gtag) {
                 gtag('consent', 'update', {
                   analytics_storage: 'granted',
@@ -222,17 +224,15 @@
       localStorage.removeItem('show_consent_bar');
       localStorage.removeItem('consent_date');
 
-          // Check if simulated country is North America
-    const safeCountries = ['US', 'CA', 'MX', 'AU', 'NZ', 'JP', 'KR', 'SG', 'HK'];
-    const isNorthAmerica = safeCountries.includes(countryCode);
-      const shouldShowBar = !isNorthAmerica;
+      // Only EU/EEA + UK visitors are prompted; everyone else is opt-out.
+      const shouldShowBar = CONSENT_REQUIRED_COUNTRIES.includes(countryCode);
 
       // Show/hide the consent bar
       if (shouldShowBar) {
         showConsentBar();
       } else {
         hideConsentBar();
-        // Auto-grant consent for North American users
+        // Auto-grant consent for visitors outside the EU/EEA + UK
         if (window.gtag) {
           gtag('consent', 'update', {
             analytics_storage: 'granted',

--- a/sections/footer.liquid
+++ b/sections/footer.liquid
@@ -3,6 +3,9 @@
     <div class="row mt-4 pt-4 border-top border-secondary border-opacity-25">
       <div class="col text-center">
         <small class="">© {{ 'now' | date: '%Y' }} aimii.app | Built by @fevish</small>
+        <div class="mt-2">
+          <small><a href="/privacy-policy" class="link-secondary text-decoration-none">Privacy Policy</a> · <a href="/terms" class="link-secondary text-decoration-none">Terms of Use</a></small>
+        </div>
       </div>
     </div>
   </div>

--- a/terms.md
+++ b/terms.md
@@ -1,0 +1,79 @@
+---
+layout: privacy
+---
+# Terms of Use
+
+**Last updated:** June 4 2026
+
+### TL;DR
+
+**IN HUMAN LANGUAGE:** aimii is a free tool for personal use, provided as-is. Use it sensibly, don't abuse it, and understand we can't guarantee it's perfect. By installing it, you agree to the terms below.
+
+---
+
+These Terms of Use ("Terms") govern your use of the aimii.app desktop application and website (together, the "App"). By installing or using the App, you agree to these Terms. If you do not agree, do not install or use the App.
+
+These Terms are an agreement between you and aimii.app ("aimii", "we", "us") only, and **not** with Overwolf. aimii is an application built on and distributed through the Overwolf platform; your use of the Overwolf platform itself is governed by Overwolf's own terms.
+
+### License
+
+Subject to these Terms, we grant you a limited, non-exclusive, revocable, non-transferable, non-sublicensable, worldwide license to download and use the App solely for your personal, non-commercial use.
+
+You may not sell, rent, sublicense, reverse engineer (except where permitted by law), or redistribute the App, or use it in any way not expressly permitted by these Terms.
+
+### Acceptable use
+
+You agree to use the App in compliance with all applicable laws and with the terms and policies of any game you use it alongside. You are responsible for ensuring that using aimii does not violate the rules of the games you play. aimii performs local game detection and sensitivity calculations only; you use it at your own discretion and responsibility.
+
+### Intellectual property
+
+aimii and its original content, features, and branding are and remain our property. You receive no ownership in the App beyond the license granted above.
+
+You acknowledge that, in the event of any third-party claim that the App, or your possession or use of the App, infringes that third party's intellectual property rights, aimii — and not Overwolf — will be solely responsible for the investigation, defense, settlement, and discharge of any such intellectual property infringement claim.
+
+### Third-party services
+
+The App may link to or interoperate with third-party services, including the Overwolf platform, GitHub, Discord, and the games you play. We do not control these services and are not responsible for their content, practices, or availability. Any use of third-party services is at your own risk and subject to their respective terms.
+
+### Disclaimer of warranties
+
+THE APP IS PROVIDED "AS IS" AND "AS AVAILABLE", WITHOUT WARRANTIES OF ANY KIND, WHETHER EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO IMPLIED WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, ACCURACY, AND NON-INFRINGEMENT. You use the App at your own risk. We do not warrant that the App will be uninterrupted, error-free, or that sensitivity conversions will be perfectly accurate for every game or setup.
+
+### Assumption of risk (games and anti-cheat)
+
+You use the App alongside any game entirely at your own risk. aimii performs local game detection and sensitivity calculations only; it does not modify games. **aimii is not responsible for any consequences of using the App with any game, including account suspensions, bans, or anti-cheat actions.** You are solely responsible for ensuring that your use of the App complies with the rules, terms, and anti-cheat policies of every game you play.
+
+### Limitation of liability
+
+To the maximum extent permitted by applicable law:
+
+- The App is provided free of charge, and aimii's total aggregate liability to you for any and all claims arising out of or relating to the App or these Terms will not exceed the amount you paid to use the App — which is zero.
+- aimii will not be liable for any indirect, incidental, special, consequential, exemplary, or punitive damages, or for any loss of data, profits, or goodwill, arising out of or related to your use of (or inability to use) the App.
+
+Some jurisdictions do not allow certain exclusions or limitations of liability, so some of the above may not apply to you. Nothing in these Terms limits any liability that cannot be limited or excluded under applicable law.
+
+### Indemnification
+
+To the maximum extent permitted by law, you agree to indemnify and hold harmless aimii from any claims, damages, losses, or expenses (including reasonable legal fees) arising out of your use or misuse of the App, your violation of these Terms, or your violation of any third party's rights or any game's rules.
+
+### Support
+
+aimii is a free, solo-developed project. We are solely responsible for any maintenance and support we choose to provide, but we are under no obligation to provide support, updates, or fixes. Community support is available via our Discord.
+
+### Termination
+
+We may suspend or discontinue the App, or revoke your license, at any time. You may stop using and uninstall the App at any time. Sections that by their nature should survive termination (including intellectual property, disclaimers, and limitation of liability) will survive.
+
+### Governing law
+
+These Terms are governed by the laws of Canada and the applicable provincial laws therein, without regard to conflict-of-law principles.
+
+### Changes
+
+We may update these Terms from time to time. The "Last updated" date above reflects the most recent version. Continued use of the App after changes constitutes acceptance.
+
+### Contact
+
+Questions, complaints, or claims regarding these Terms can be sent to:
+
+**Email:** fevish@gmail.com


### PR DESCRIPTION
…wolf

Rewrites privacy-policy.md into a full app privacy policy (local-only app, Overwolf ad SDK, Google Analytics, ipapi.co), adds terms.md (license, game-ban/anti-cheat disclaimer, $0 liability cap, indemnification, Overwolf IP clause), and links both from the footer. Narrows cookie consent to prompt only EU/EEA + UK visitors (opt-out elsewhere).